### PR TITLE
[Controller][Serialization] Allow custom serialization contexts

### DIFF
--- a/src/TreeHouse/BaseApiBundle/Behat/ApiContext.php
+++ b/src/TreeHouse/BaseApiBundle/Behat/ApiContext.php
@@ -17,7 +17,7 @@ class ApiContext extends BaseFeatureContext
      * @var string
      */
     protected static $userToken;
-    
+
     /**
      * @BeforeScenario
      */

--- a/src/TreeHouse/BaseApiBundle/Tests/Mock/ApiControllerMock.php
+++ b/src/TreeHouse/BaseApiBundle/Tests/Mock/ApiControllerMock.php
@@ -2,6 +2,7 @@
 
 namespace TreeHouse\BaseApiBundle\Tests\Mock;
 
+use JMS\Serializer\SerializationContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use TreeHouse\BaseApiBundle\Controller\BaseApiController;
@@ -28,18 +29,35 @@ class ApiControllerMock extends BaseApiController
         return $this->createResponse($statusCode);
     }
 
-    public function doRenderOk(Request $request, $result, $code = 200, array $groups = [], array $metadata = [])
-    {
-        return $this->renderOk($request, $result, $code, $groups, $metadata);
+    public function doRenderOk(
+        Request $request,
+        $result,
+        $code = 200,
+        array $groups = [],
+        array $metadata = [],
+        SerializationContext $context = null
+    ) {
+        return $this->renderOk($request, $result, $code, $groups, $metadata, $context);
     }
 
-    public function doRenderError(Request $request, $code = 400, $error, array $groups = [])
-    {
-        return $this->renderError($request, $code, $error, $groups);
+    public function doRenderError(
+        Request $request,
+        $code = 400,
+        $error,
+        array $groups = [],
+        SerializationContext $context = null
+    ) {
+        return $this->renderError($request, $code, $error, $groups, $context);
     }
 
-    public function doRenderResponse(Request $request, array $result = [], $ok, $statusCode, array $groups = [])
-    {
-        return $this->renderResponse($request, $result, $ok, $statusCode, $groups);
+    public function doRenderResponse(
+        Request $request,
+        array $result = [],
+        $ok,
+        $statusCode,
+        array $groups = [],
+        SerializationContext $context = null
+    ) {
+        return $this->renderResponse($request, $result, $ok, $statusCode, $groups, $context);
     }
 }


### PR DESCRIPTION
We need this so we can modify the context used to serialize objects. In our case we needed to add an attribute so we could access it within a serialization listener.

Unfortunately we now have a `$groups` argument and a `$context` argument, while `$groups` in the end is assigned to the `$context` argument, which causes a bit of redundancy: https://github.com/treehouselabs/TreeHouseBaseApiBundle/blob/9349309f452b3fbbb9a230399d21b638a94eed1f/src/TreeHouse/BaseApiBundle/Controller/BaseApiController.php#L128-L130. 

Not sure how to solve this, or if we should just keep it this way to stay backwards-compatible?
